### PR TITLE
Add support for crystal 1.x

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: orion
-crystal: ">= 0.36.1"
+crystal: ">= 0.36.0 - 1.0"
 version: 3.0.3
 homepage: https://obsidian.github.io/orion
 documentation: https://obsidian.github.io/orion


### PR DESCRIPTION
Hi @jwaldrip,

This `PR` adds support for `crystal` `v1.x`.

Releasing a new version with this patch allows me to tick `orion` in https://github.com/the-benchmarker/web-frameworks/pull/4098

Regards,