### PR TITLE
Add crystal 1.x support

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -9,9 +9,10 @@ authors:
 dependencies:
   oak:
     github: obsidian/oak
-    version: ">= 4.0.1"
+    version: "~> 4.0.1"
   inflector:
     github: phoffer/inflector.cr
+    version: "~> 1.0.0"
   kilt:
     github: jeromegn/kilt
   exception_page:


### PR DESCRIPTION
Hi @jwaldrip,

This `PR` add support for `crystal` **v1**.

The dependency `inflector.cr` has been updated on this purpose.

Regards,